### PR TITLE
Reverts modifs on template folder name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 # ignore python pyc files
 *.pyc
 
+# ignore PyCharm editor files
+*.idea
+
 ## Intermediate documents:
 *.dvi
 *.xdv

--- a/Author_Template/Makefile
+++ b/Author_Template/Makefile
@@ -129,14 +129,14 @@ clean:
 	rm -f $(P).dvi $(P).bbl $(P).blg $(P).pdf $(P).aux $(P).log $(P).out $(P).toc $(P)_inc.tex
 
 check:
-	PaperCheck.py $(P) $(A)
+	./PaperCheck.py $(P) $(A)
 
 ENCODING =
 fix:
-	FixUnprintable.py  $(P).tex $(ENCODING)
+	./FixUnprintable.py  $(P).tex $(ENCODING)
 
 inc:
-	tex2inc.py $(P).tex > $(P)_inc.tex
+	./tex2inc.py $(P).tex > $(P)_inc.tex
 	@tail -1 $(P)_inc.tex
 	@cat $(P).toc
 
@@ -151,7 +151,7 @@ dvi:
 	latex $(P)
 
 aindex:
-	Aindex.py $(P)
+	./Aindex.py $(P)
 
 DETEX = detex
 words:
@@ -190,7 +190,7 @@ asp1:
 TERMS = foobar
 index:
 	@echo Using TERMS=$(TERMS)
-	(cd ../Author_Template; Index.py $(TERMS))
+	(cd ../Author_Template; ./Index.py $(TERMS))
 
 ssindex:
 	@echo Generating ssindex list
@@ -208,9 +208,9 @@ ascl:
 # 	(cd ../Author_Template; ./ascl-new.py ../../ADASSProceedings2020/papers/$(P)/$(P).tex)
 
 ascl1:
-	(cd ../Author_Template; ascl.py ../../ADASSProceedings2020/papers/$(P)/$(P).tex | grep ooindex | sort | uniq -c)
+	(cd ../Author_Template; ./ascl.py ../../ADASSProceedings2020/papers/$(P)/$(P).tex | grep ooindex | sort | uniq -c)
 	-detex $(P).tex > $(P).txt
-	-(cd ../Author_Template; ascl.py ../../ADASSProceedings2020/papers/$(P)/$(P).txt | grep ooindex | sort | uniq -c)
+	-(cd ../Author_Template; ./ascl.py ../../ADASSProceedings2020/papers/$(P)/$(P).txt | grep ooindex | sort | uniq -c)
 	-grep ooindex $(P).tex
 
 CODE = foobar

--- a/Author_Template/PaperCheck.py
+++ b/Author_Template/PaperCheck.py
@@ -689,9 +689,9 @@ def CheckSubjectIndexEntries(Paper, Problems, TexFileName = "") :
     # Read the total list of keywords from subjectKeywords.txt and newKeywords.txt
     # Is there a better way to use AdassConfig.* methods to point at relative file paths?
     Entries = compose(set, Reduce(__add__), Map(AdassIndex.ReadIndexList))(
-                      ['../ADASS2020_Author_Template/subjectKeywords.txt', '../ADASS2020_Author_Template/newKeywords.txt'] )
+                      ['../Author_Template/subjectKeywords.txt', '../Author_Template/newKeywords.txt'] )
     if not Entries:
-        Problems.append( "No subject keywords found **at all**?! (../ADASS2020_Author_Template/{subject|new}Keywords.txt missing?" )
+        Problems.append( "No subject keywords found **at all**?! (../Author_Template/{subject|new}Keywords.txt missing?" )
         return False
 
     # ssindex entries that are not in Entries pose a problem!


### PR DESCRIPTION
This PR reverts previous modifications done in dealing with template folder name, as explained in issue https://github.com/astroumd/ADASSProceedings/issues/2

It also adds dot slash syntax to execute python scripts in the working folder for those terminals not having "." declared in the $PATH