### PR TITLE
Add .INTERMEDIATE for the empty copyrightform

### DIFF
--- a/Author_Template/Makefile
+++ b/Author_Template/Makefile
@@ -97,6 +97,9 @@ export:
 	-git branch                        >> $(ATDIR)/VERSION
 	tar cf ADASS$(YEAR).tar $(ATDIR)
 
+# If one has created filled and renamed their copyrightform, prevent Make from failing
+.INTERMEDIATE : copyrightform.pdf
+
 # copyright is now part of the tar/zip file, checksum (sum) is 13785
 copyrightform_$(P)_$(A).pdf: copyrightform.pdf
 	cp copyrightform.pdf copyrightform_$(P)_$(A).pdf


### PR DESCRIPTION
This makes the dependency on the copyrightform to only be resolved if the target does not exist.

This may happen when someone fills in the copyright form and renames it for instance.